### PR TITLE
Added cross-compiling to Scala3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.11, 2.12.18, 2.11.12]
+        scala: [3.3.1, 2.13.12, 2.12.18, 2.11.12]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.11]
+        scala: [3.3.1, 2.13.12]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -93,10 +93,10 @@ lazy val scalac213: Seq[String] = Seq(
 )
 
 lazy val scalac3: Seq[String] = Seq(
-  "-source:3.0-migration"
+  "-source:3.0-migration" // makes the compiler forgiving on most of the dropped features, printing warnings in place of errors
 )
 
-lazy val scala213 = "2.13.11"
+lazy val scala213 = "2.13.12"
 lazy val scala212 = "2.12.18"
 lazy val scala211 = "2.11.12"
 lazy val scala3   = "3.3.1"

--- a/build.sbt
+++ b/build.sbt
@@ -92,13 +92,17 @@ lazy val scalac213: Seq[String] = Seq(
   "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
 )
 
+lazy val scalac3: Seq[String] = Seq(
+  "-source:3.0-migration"
+)
 
 lazy val scala213 = "2.13.11"
 lazy val scala212 = "2.12.18"
 lazy val scala211 = "2.11.12"
+lazy val scala3   = "3.3.1"
 
-crossScalaVersions := Seq(scala211, scala212, scala213)
-scalaVersion := scala212
+crossScalaVersions := Seq(scala211, scala212, scala213, scala3)
+scalaVersion := scala213
 organization := "org.scorexfoundation"
 
 javacOptions ++=
@@ -112,18 +116,28 @@ lazy val utilSettings = Seq(
   homepage := Some(url("http://github.com/ScorexFoundation/scorex-util")),
   description := "Common tools for scorex projects",
 
-  resolvers += Resolver.sonatypeRepo("public"),
+  resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
   libraryDependencies ++= Seq(
-//    scalaOrganization.value % "scala-reflect" % scalaVersion.value % "provided",
-    "org.rudogma" %%% "supertagged" % "2.0-RC2",
-    "org.scalatest" %%% "scalatest" % "3.3.0-SNAP3" % Test,
-    "org.scalatest" %%% "scalatest-propspec" % "3.3.0-SNAP3" % Test,
-    "org.scalatest" %%% "scalatest-shouldmatchers" % "3.3.0-SNAP3" % Test,
-    "org.scalatestplus" %%% "scalacheck-1-15" % "3.3.0.0-SNAP3" % Test,
-    "org.scalacheck" %%% "scalacheck" % "1.15.2" % Test
-  ),
-
-  scalacOptions := {
+    ("org.rudogma" %%% "supertagged" % "2.0-RC2").cross(CrossVersion.for3Use2_13),
+  ) ++ {
+    if (scalaVersion.value == scala3)
+      Seq(
+        "org.scalatest" %%% "scalatest" % "3.3.0-alpha.1" % Test,
+        "org.scalatest" %%% "scalatest-propspec" % "3.3.0-alpha.1" % Test,
+        "org.scalatest" %%% "scalatest-shouldmatchers" % "3.3.0-alpha.1" % Test,
+        "org.scalacheck" %%% "scalacheck" % "1.15.3" % Test,
+        "org.scalatestplus" %%% "scalacheck-1-17" % "3.3.0.0-alpha.1" % Test
+      )
+    else // use last versions with Scala 2.11 support
+      Seq(
+        "org.scalatest" %%% "scalatest" % "3.3.0-SNAP3" % Test,
+        "org.scalatest" %%% "scalatest-propspec" % "3.3.0-SNAP3" % Test,
+        "org.scalatest" %%% "scalatest-shouldmatchers" % "3.3.0-SNAP3" % Test,
+        "org.scalacheck" %%% "scalacheck" % "1.15.2" % Test,
+        "org.scalatestplus" %%% "scalacheck-1-15" % "3.3.0.0-SNAP3" % Test
+      )
+  },
+  scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, n)) if n == 13 =>
         scalac ++ scalac213
@@ -131,6 +145,8 @@ lazy val utilSettings = Seq(
         scalac ++ scalac212
       case Some((2, 11)) =>
         scalac ++ scalac211
+      case Some((3, _)) =>
+        scalac ++ scalac3
     }
   },
   javacOptions ++= javacReleaseOption,
@@ -161,17 +177,17 @@ lazy val utilSettings = Seq(
 lazy val core = crossProject(JSPlatform, JVMPlatform)
     .in(file("."))
     .settings(moduleName := "scorex-util")
-    .settings(utilSettings)
     .jvmSettings(
       scalaVersion := scala213,
-      crossScalaVersions := Seq(scala211, scala212, scala213),
+      crossScalaVersions := Seq(scala211, scala212, scala213, scala3),
       libraryDependencies ++= Seq(
-        "com.typesafe.scala-logging" %%% "scala-logging" % "3.9.2"
+        "com.typesafe.scala-logging" %%% "scala-logging" % "3.9.5"
       ),
     )
+    .settings(utilSettings)
     .jsSettings(
       scalaVersion := scala213,
-      crossScalaVersions := Seq(scala213),
+      crossScalaVersions := Seq(scala3, scala213),
       libraryDependencies ++= Seq(
       ),
       Test / parallelExecution := false

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,6 @@ lazy val scalac: Seq[String] = Seq(
   "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
 //  "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
   // "-Ypartial-unification",             // Enable partial unification in type constructor inference
-  "-Ywarn-dead-code",                  // Warn when dead code is identified.
-  "-Ywarn-numeric-widen"              // Warn when numerics are widened.
   //"-Xlog-free-terms",
 )
 
@@ -24,6 +22,9 @@ lazy val scalac211: Seq[String] = Seq(
   "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
   "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
   "-Xfuture",                          // Turn on future language features.
+  "-Ywarn-dead-code",                  // Warn when dead code is identified.
+  "-Ywarn-numeric-widen"               // Warn when numerics are widened.
+
 )
 
 lazy val scalac212: Seq[String] = Seq(
@@ -61,6 +62,9 @@ lazy val scalac212: Seq[String] = Seq(
   "-Xlint:unsound-match",              // Pattern match may not be typesafe.
   "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
   "-Xfuture",                          // Turn on future language features.
+  "-Ywarn-dead-code",                  // Warn when dead code is identified.
+  "-Ywarn-numeric-widen"               // Warn when numerics are widened.
+
 )
 
 lazy val scalac213: Seq[String] = Seq(
@@ -90,6 +94,9 @@ lazy val scalac213: Seq[String] = Seq(
   "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
   "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
   "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+  "-Ywarn-dead-code",                  // Warn when dead code is identified.
+  "-Ywarn-numeric-widen"               // Warn when numerics are widened.
+
 )
 
 lazy val scalac3: Seq[String] = Seq(

--- a/shared/src/test/scala/scorex/util/ExtensionsSpecification.scala
+++ b/shared/src/test/scala/scorex/util/ExtensionsSpecification.scala
@@ -11,93 +11,93 @@ class ExtensionsSpecification extends AnyPropSpec
   with Matchers {
 
   property("ByteOps.toUByte") {
-    forAll { b: Byte =>
+    forAll { (b: Byte) =>
       val expected = if (b >= 0) b.toInt else 255 + b + 1
       b.toUByte shouldBe expected
     }
   }
 
   property("ShortOps.toByteExact") {
-    forAll(Gen.chooseNum(Byte.MaxValue.toShort, Byte.MaxValue.toShort)) { x: Short =>
+    forAll(Gen.chooseNum(Byte.MaxValue.toShort, Byte.MaxValue.toShort)) { (x: Short) =>
       x.toByteExact shouldBe x.toByte
     }
 
-    forAll(Gen.chooseNum(Short.MinValue, (Byte.MinValue - 1).toShort)) { x: Short =>
+    forAll(Gen.chooseNum(Short.MinValue, (Byte.MinValue - 1).toShort)) { (x: Short) =>
       an[ArithmeticException] should be thrownBy x.toByteExact
     }
 
-    forAll(Gen.chooseNum((Byte.MaxValue + 1).toShort, Short.MaxValue)) { x: Short =>
+    forAll(Gen.chooseNum((Byte.MaxValue + 1).toShort, Short.MaxValue)) { (x: Short) =>
       an[ArithmeticException] should be thrownBy x.toByteExact
     }
 
   }
 
   property("IntOps.toByteExact") {
-    forAll(Gen.chooseNum(Byte.MaxValue.toInt, Byte.MaxValue.toInt)) { x: Int =>
+    forAll(Gen.chooseNum(Byte.MaxValue.toInt, Byte.MaxValue.toInt)) { (x: Int) =>
       x.toByteExact shouldBe x.toByte
     }
 
-    forAll(Gen.chooseNum(Int.MinValue, Byte.MinValue - 1)) { x: Int =>
+    forAll(Gen.chooseNum(Int.MinValue, Byte.MinValue - 1)) { (x: Int) =>
       an[ArithmeticException] should be thrownBy x.toByteExact
     }
 
-    forAll(Gen.chooseNum(Byte.MaxValue + 1, Int.MaxValue)) { x: Int =>
+    forAll(Gen.chooseNum(Byte.MaxValue + 1, Int.MaxValue)) { (x: Int) =>
       an[ArithmeticException] should be thrownBy x.toByteExact
     }
   }
 
   property("IntOps.toShortExact") {
-    forAll(Gen.chooseNum(Short.MaxValue.toInt, Short.MaxValue.toInt)) { x: Int =>
+    forAll(Gen.chooseNum(Short.MaxValue.toInt, Short.MaxValue.toInt)) { (x: Int) =>
       x.toShortExact shouldBe x.toShort
     }
 
-    forAll(Gen.chooseNum(Int.MinValue, Short.MinValue - 1)) { x: Int =>
+    forAll(Gen.chooseNum(Int.MinValue, Short.MinValue - 1)) { (x: Int) =>
       an[ArithmeticException] should be thrownBy x.toShortExact
     }
 
-    forAll(Gen.chooseNum(Short.MaxValue + 1, Int.MaxValue)) { x: Int =>
+    forAll(Gen.chooseNum(Short.MaxValue + 1, Int.MaxValue)) { (x: Int) =>
       an[ArithmeticException] should be thrownBy x.toShortExact
     }
   }
 
   property("LongOps.toByteExact") {
-    forAll(Gen.chooseNum(Byte.MaxValue.toLong, Byte.MaxValue.toLong)) { x: Long =>
+    forAll(Gen.chooseNum(Byte.MaxValue.toLong, Byte.MaxValue.toLong)) { (x: Long) =>
       x.toByteExact shouldBe x.toByte
     }
 
-    forAll(Gen.chooseNum(Long.MinValue, (Byte.MinValue - 1).toLong)) { x: Long =>
+    forAll(Gen.chooseNum(Long.MinValue, (Byte.MinValue - 1).toLong)) { (x: Long) =>
       an[ArithmeticException] should be thrownBy x.toByteExact
     }
 
-    forAll(Gen.chooseNum((Byte.MaxValue + 1).toLong, Long.MaxValue)) { x: Long =>
+    forAll(Gen.chooseNum((Byte.MaxValue + 1).toLong, Long.MaxValue)) { (x: Long) =>
       an[ArithmeticException] should be thrownBy x.toByteExact
     }
   }
 
   property("LongOps.toShortExact") {
-    forAll(Gen.chooseNum(Short.MaxValue.toLong, Short.MaxValue.toLong)) { x: Long =>
+    forAll(Gen.chooseNum(Short.MaxValue.toLong, Short.MaxValue.toLong)) { (x: Long) =>
       x.toShortExact shouldBe x.toShort
     }
 
-    forAll(Gen.chooseNum(Long.MinValue, (Short.MinValue - 1).toLong)) { x: Long =>
+    forAll(Gen.chooseNum(Long.MinValue, (Short.MinValue - 1).toLong)) { (x: Long) =>
       an[ArithmeticException] should be thrownBy x.toShortExact
     }
 
-    forAll(Gen.chooseNum((Short.MaxValue + 1).toLong, Long.MaxValue)) { x: Long =>
+    forAll(Gen.chooseNum((Short.MaxValue + 1).toLong, Long.MaxValue)) { (x: Long) =>
       an[ArithmeticException] should be thrownBy x.toShortExact
     }
   }
 
   property("LongOps.toIntExact") {
-    forAll(Gen.chooseNum(Int.MaxValue.toLong, Int.MaxValue.toLong)) { x: Long =>
+    forAll(Gen.chooseNum(Int.MaxValue.toLong, Int.MaxValue.toLong)) { (x: Long) =>
       x.toIntExact shouldBe x.toInt
     }
 
-    forAll(Gen.chooseNum(Long.MinValue, Int.MinValue.toLong - 1)) { x: Long =>
+    forAll(Gen.chooseNum(Long.MinValue, Int.MinValue.toLong - 1)) { (x: Long) =>
       an[ArithmeticException] should be thrownBy x.toIntExact
     }
 
-    forAll(Gen.chooseNum(Int.MaxValue.toLong + 1, Long.MaxValue)) { x: Long =>
+    forAll(Gen.chooseNum(Int.MaxValue.toLong + 1, Long.MaxValue)) { (x: Long) =>
       an[ArithmeticException] should be thrownBy x.toIntExact
     }
   }

--- a/shared/src/test/scala/scorex/util/ExtensionsSpecification.scala
+++ b/shared/src/test/scala/scorex/util/ExtensionsSpecification.scala
@@ -104,7 +104,7 @@ class ExtensionsSpecification extends AnyPropSpec
 
   property("TraversableOps.cast") {
     List(1,2,3,4).cast[Int] shouldBe List(1,2,3,4)
-    an[IllegalArgumentException] should be thrownBy List(1,"2",3,4).cast[Int]
+    an[IllegalArgumentException] should be thrownBy List[Any](1,"2",3,4).cast[Int]
   }
 
 }

--- a/shared/src/test/scala/scorex/util/encode/BytesEncoderSpecification.scala
+++ b/shared/src/test/scala/scorex/util/encode/BytesEncoderSpecification.scala
@@ -13,7 +13,7 @@ trait BytesEncoderSpecification extends AnyPropSpec
   val encoder: BytesEncoder
 
   property("Encoding then decoding preserves data") {
-    forAll { data: Array[Byte] =>
+    forAll { (data: Array[Byte]) =>
       whenever(data.length > 0 && data.head != 0) {
         val encoded = encoder.encode(data)
         encoded.find(c => !encoder.Alphabet.contains(c)) shouldBe None
@@ -24,7 +24,7 @@ trait BytesEncoderSpecification extends AnyPropSpec
   }
 
   property("Decoding should return failure on incorrect characters") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       whenever(str.exists(c => !encoder.Alphabet.contains(c))) {
         encoder.decode(str).isFailure shouldBe true
       }

--- a/shared/src/test/scala/scorex/util/encode/ZigZagSpecification.scala
+++ b/shared/src/test/scala/scorex/util/encode/ZigZagSpecification.scala
@@ -36,13 +36,13 @@ class ZigZagSpecification extends AnyPropSpec
   }
 
   property("ZigZag Long round trip") {
-    forAll(Gen.chooseNum(Long.MinValue, Long.MaxValue)) { v: Long =>
+    forAll(Gen.chooseNum(Long.MinValue, Long.MaxValue)) { (v: Long) =>
       decodeZigZagLong(encodeZigZagLong(v)) shouldBe v
     }
   }
 
   property("ZigZag Int round trip") {
-    forAll(Gen.chooseNum(Int.MinValue, Int.MaxValue)) { v: Int =>
+    forAll(Gen.chooseNum(Int.MinValue, Int.MaxValue)) { (v: Int) =>
       decodeZigZagInt(encodeZigZagInt(v)) shouldBe v
     }
   }

--- a/shared/src/test/scala/scorex/util/serialization/VLQReaderWriterSpecification.scala
+++ b/shared/src/test/scala/scorex/util/serialization/VLQReaderWriterSpecification.scala
@@ -70,7 +70,7 @@ trait VLQReaderWriterSpecification extends AnyPropSpec
   property("round trip serialization/deserialization of arbitrary value list") {
     // increase threshold to make sure we cover a lot of types combination
     // and a good diversity withing a values of the each type
-    forAll(seqPrimValGen, minSuccessful(500)) { values: Seq[Any] =>
+    forAll(seqPrimValGen, minSuccessful(500)) { (values: Seq[Any]) =>
       val writer = byteArrayWriter()
       for (any <- values) {
         any match {
@@ -122,7 +122,7 @@ trait VLQReaderWriterSpecification extends AnyPropSpec
     // Gen.choose does not always include range limit values
     bytesLong(low).length shouldBe size
     bytesLong(high).length shouldBe size
-    forAll(Gen.choose(low, high)) { v: Long =>
+    forAll(Gen.choose(low, high)) { (v: Long) =>
       bytesLong(v).length shouldBe size
     }
   }
@@ -148,7 +148,7 @@ trait VLQReaderWriterSpecification extends AnyPropSpec
     // Gen.choose does not always include range limit values
     bytesZigZaggedLong(low).length shouldBe size
     bytesZigZaggedLong(high).length shouldBe size
-    forAll(Gen.choose(low, high)) { v: Long =>
+    forAll(Gen.choose(low, high)) { (v: Long) =>
       bytesZigZaggedLong(v).length shouldBe size
     }
   }
@@ -185,7 +185,7 @@ trait VLQReaderWriterSpecification extends AnyPropSpec
   }
 
   property("fail deserialization by deliberately messing with different methods") {
-    forAll(Gen.chooseNum(1L, Long.MaxValue)) { v: Long =>
+    forAll(Gen.chooseNum(1L, Long.MaxValue)) { (v: Long) =>
       val writer = byteArrayWriter()
       writer.putULong(v)
       writer.putLong(v)
@@ -306,52 +306,52 @@ trait VLQReaderWriterSpecification extends AnyPropSpec
   }
 
   property("Byte roundtrip") {
-    forAll { v: Byte => byteBufReader(byteArrayWriter().put(v).toBytes).getByte() shouldBe v }
+    forAll { (v: Byte) => byteBufReader(byteArrayWriter().put(v).toBytes).getByte() shouldBe v }
   }
 
   property("unsigned Byte roundtrip") {
-    forAll { v: Byte =>
+    forAll { (v: Byte) =>
       val uv: Int = v & 0xFF
       byteBufReader(byteArrayWriter().putUByte(uv).toBytes).getUByte() shouldBe uv
     }
   }
 
   property("Short roundtrip") {
-    forAll { v: Short => byteBufReader(byteArrayWriter().putShort(v).toBytes).getShort() shouldBe v }
+    forAll { (v: Short) => byteBufReader(byteArrayWriter().putShort(v).toBytes).getShort() shouldBe v }
   }
 
   property("unsigned Short roundtrip") {
-    forAll { v: Short =>
+    forAll { (v: Short) =>
       val uv: Int = v & 0xFFFF
       byteBufReader(byteArrayWriter().putUShort(uv).toBytes).getUShort() shouldBe uv
     }
   }
 
   property("Int roundtrip") {
-    forAll { v: Int => byteBufReader(byteArrayWriter().putInt(v).toBytes).getInt() shouldBe v }
+    forAll { (v: Int) => byteBufReader(byteArrayWriter().putInt(v).toBytes).getInt() shouldBe v }
   }
 
   property("unsigned Int roundtrip") {
-    forAll { v: Int =>
+    forAll { (v: Int) =>
       val uv: Long = v.toLong + (Int.MinValue.toLong * -1)
       byteBufReader(byteArrayWriter().putUInt(uv).toBytes).getUInt() shouldBe uv
     }
   }
 
   property("Long roundtrip") {
-    forAll { v: Long => byteBufReader(byteArrayWriter().putLong(v).toBytes).getLong() shouldBe v }
+    forAll { (v: Long) => byteBufReader(byteArrayWriter().putLong(v).toBytes).getLong() shouldBe v }
   }
 
   property("ULong roundtrip") {
-    forAll { v: Long => byteBufReader(byteArrayWriter().putULong(v).toBytes).getULong() shouldBe v }
+    forAll { (v: Long) => byteBufReader(byteArrayWriter().putULong(v).toBytes).getULong() shouldBe v }
   }
 
   property("Boolean array roundtrip") {
-    forAll { v: Array[Boolean] => byteBufReader(byteArrayWriter().putBits(v).toBytes).getBits(v.length) shouldBe v }
+    forAll { (v: Array[Boolean]) => byteBufReader(byteArrayWriter().putBits(v).toBytes).getBits(v.length) shouldBe v }
   }
 
   property("short string roundtrip") {
-    forAll(Gen.alphaStr.suchThat(_.length < 256)) { v: String =>
+    forAll(Gen.alphaStr.suchThat(_.length < 256)) { (v: String) =>
       byteBufReader(byteArrayWriter().putShortString(v).toBytes).getShortString() shouldBe v
     }
   }
@@ -636,7 +636,7 @@ trait VLQReaderWriterSpecification extends AnyPropSpec
   }
 
   property("putShort, putInt, putLong equivalence") {
-    forAll { v: Short =>
+    forAll { (v: Short) =>
       val expected = byteArrayWriter().putShort(v).toBytes
       byteArrayWriter().putInt(v.toInt).toBytes shouldEqual expected
       byteArrayWriter().putLong(v.toLong).toBytes shouldEqual expected

--- a/shared/src/test/scala/scorex/util/serialization/VLQReaderWriterSpecification.scala
+++ b/shared/src/test/scala/scorex/util/serialization/VLQReaderWriterSpecification.scala
@@ -185,7 +185,7 @@ trait VLQReaderWriterSpecification extends AnyPropSpec
   }
 
   property("fail deserialization by deliberately messing with different methods") {
-    forAll(Gen.chooseNum(1, Long.MaxValue)) { v: Long =>
+    forAll(Gen.chooseNum(1L, Long.MaxValue)) { v: Long =>
       val writer = byteArrayWriter()
       writer.putULong(v)
       writer.putLong(v)

--- a/shared/src/test/scala/scorex/util/serialization/VLQReaderWriterSpecification.scala
+++ b/shared/src/test/scala/scorex/util/serialization/VLQReaderWriterSpecification.scala
@@ -19,7 +19,7 @@ trait VLQReaderWriterSpecification extends AnyPropSpec
   private val seqPrimValGen: Gen[Seq[Any]] = for {
     length <- Gen.chooseNum(1, 1000)
     anyValSeq <- Gen.listOfN(length,
-      Gen.oneOf(
+      Gen.oneOf[Any](
         Arbitrary.arbByte.arbitrary,
         Arbitrary.arbShort.arbitrary,
         Arbitrary.arbInt.arbitrary,


### PR DESCRIPTION
In this PR:
- build.sbt is configured (Scala3 compiler with `-source:3.0-migration` mode)
- compilation errors fixed
- removed migration warnings for Scala 2 features dropped in Scala 3 
